### PR TITLE
feat: Add OTP generation and verification for rides

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -824,6 +824,7 @@ Authorization: Bearer your_jwt_token
       "destination": "string", // Destination location
       "fare": "number",        // Calculated fare for the ride
       "status": "string",      // Current status of the ride (e.g., "pending")
+      "otp": "string",         // 4-digit OTP for ride verification
       "_id": "string",         // Unique ride ID
       "__v": "number"          // Version key
     }

--- a/backend/models/ride.model.js
+++ b/backend/models/ride.model.js
@@ -27,6 +27,12 @@ const rideSchema = new mongoose.Schema({
     enum: ["pending", "accepted", "ongoing", "completed", "cancelled"],
     default: "pending",
   },
+  otp: {
+    type: String,
+    selected: false,
+    required: true,
+    length: 4,
+  },
   duration: {
     type: Number, // in seconds
   },

--- a/backend/services/ride.service.js
+++ b/backend/services/ride.service.js
@@ -1,6 +1,7 @@
 const rideModel = require("../models/ride.model");
 const AppError = require("../utils/AppError");
 const mapService = require("../services/map.service");
+const crypto = require("crypto");
 
 async function getFare(pickup, destination, vehicleType) {
   if (!pickup || !destination) {
@@ -47,11 +48,18 @@ async function getFare(pickup, destination, vehicleType) {
   return Math.round(fare);
 }
 
+function getOTP(num) {
+  // Using crypto.randomInt to generate cryptographically secure random numbers
+  return Array.from({ length: num }, () => crypto.randomInt(0, 10)).join("");
+}
+
 module.exports.createRide = async ({ user, pickup, destination }) => {
   if (!user || !pickup || !destination) {
     throw new AppError("User, pickup and destination are required", 400);
   }
+
   const fare = await getFare(pickup, destination, user.vehicleType);
+  const otp = getOTP(4);
 
   const ride = await rideModel.create({
     user: user.id,
@@ -59,6 +67,7 @@ module.exports.createRide = async ({ user, pickup, destination }) => {
     destination,
     fare,
     status: "pending",
+    otp,
   });
 
   return ride;


### PR DESCRIPTION
- Add OTP field to ride model with selected:false for security
- Implement crypto-based OTP generation in ride service
- Update API documentation with OTP field in response

This change adds a secure 4-digit OTP for ride verification